### PR TITLE
refactor: move menu item to overview menu

### DIFF
--- a/console/src/index.ts
+++ b/console/src/index.ts
@@ -2,13 +2,13 @@ import { definePlugin } from "@halo-dev/console-shared";
 import IndexView from "./views/Index.vue";
 import { markRaw } from "vue";
 import "./styles/tailwind.css";
-import MaterialSymbolsAreaChartOutlineRounded from '~icons/material-symbols/area-chart-outline-rounded';
+import MaterialSymbolsAreaChartOutlineRounded from "~icons/material-symbols/area-chart-outline-rounded";
 
 export default definePlugin({
   components: {},
   routes: [
     {
-      parentName: "Root",
+      parentName: "OverviewRoot",
       route: {
         path: "/metrics",
         name: "Metrics",
@@ -19,7 +19,6 @@ export default definePlugin({
           searchable: true,
           menu: {
             name: "指标监控",
-            group: "tool",
             icon: markRaw(MaterialSymbolsAreaChartOutlineRounded),
             priority: 0,
           },

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -4,7 +4,7 @@ metadata:
   name: plugin-metrics-graph
 spec:
   enabled: true
-  requires: ">=2.11.0"
+  requires: ">=2.12.0"
   author:
     name: guqing
     website: https://github.com/guqing


### PR DESCRIPTION
在 Halo 2.12.0-alpha.1 中，Console 已经支持子菜单项，所以现在将其放置在概览菜单下可能会比较合适。

see https://github.com/halo-dev/halo/pull/5177

<img width="977" alt="图片" src="https://github.com/guqing/plugin-metrics-graph/assets/21301288/b9474fa3-8c08-4f78-89a1-8cd289b820f6">
